### PR TITLE
(feat) add NODE_PATH

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NODE_PATH=src/


### PR DESCRIPTION
You can now reference `src/` directory without using the never-ending `../../../`.

## Example Usage

From `src/views/home/components/EventCard.js`

**BEFORE**
```
import Arrow from '../../../assets/homePage/forward-arrow2.svg';
```

**AFTER**
```
import Arrow from 'assets/homePage/forward-arrow2.svg';
```

**NOTICE THAT THERE IS NO `./` IN FRONT OF `assets`, THIS MEANS THAT YOU'RE REFERENCING `src/`.**

**YOU CAN STILL USE `./` TO REFERENCE THE SAME DIRECTORY.**

**PLEASE UPDATE, RELATIVE PATHS ARE NOT BEAUTIFUL.**